### PR TITLE
pass arguments on to vifm

### DIFF
--- a/vifmrun
+++ b/vifmrun
@@ -11,5 +11,5 @@ mkfifo "$FIFO_UEBERZUG" >/dev/null
 trap cleanup EXIT 2>/dev/null
 tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser bash 2>&1 >/dev/null &
 
-vifm
+vifm $@
 cleanup


### PR DESCRIPTION
Currently when you can start vifm through the vifmrun script all arguments like path etc are ignored. This passes the arguments onto vifm so it works as expected