### PR TITLE
 Added support for previewing font files (.ttf, .oft, etc) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The script is currently able to handle the following formats:
 * Video files
 * eBook files
 * Images and icons
+* Audio files
+* Font files
 
 Video previews are also supported by using ffmpegthumbnailer and works very well but just
 like the PDF previews there is a minor flash between each preview, this is due to
@@ -70,6 +72,10 @@ variable for easy access to the files.
         \ vifmimg audio %px %py %pw %ph %c
         \ %pc
         \ vifmimg clear
+    fileviewer <font/*>
+        \ vifmimg font %px %py %pw %ph %c
+        \ %pc
+        \ vifmimg clear
 ```
 
 You will also need to add these keybindings (preferably in the bottom of your vifmrc) in order to get the PDF scrolling functionalities:
@@ -77,7 +83,6 @@ You will also need to add these keybindings (preferably in the bottom of your vi
 ```
     map > :!vifmimg inc<CR>
     map < :!vifmimg dec<CR>
-
 ```
 
 3. In order to launch Vifm with image preview from now you'll need to use the supplied
@@ -89,6 +94,7 @@ You will also need to add these keybindings (preferably in the bottom of your vi
 * ImageMagick
 * pdftoppm (Available in the AUR as **poppler** package.)
 * epub-thumbnailer
+* fontpreview
 
 ## Credits
 * Seebye for creating [Überzug](https://github.com/seebye/ueberzug) and the initial script

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ variable for easy access to the files.
         \ vifmimg audio %px %py %pw %ph %c
         \ %pc
         \ vifmimg clear
+        
     fileviewer <font/*>
         \ vifmimg font %px %py %pw %ph %c
         \ %pc
@@ -89,16 +90,15 @@ You will also need to add these keybindings (preferably in the bottom of your vi
 **vifmrun** script
 
 ## Prerequisites
-* Überzug and Vifm (isn't this obvious?)
-* ffmpegthumbnailer
+* [Überzug](https://github.com/seebye/ueberzug) and [Vifm](https://github.com/vifm/vifm) (isn't this obvious?)
+* [ffmpegthumbnailer](https://github.com/dirkvdb/ffmpegthumbnailer)
 * ImageMagick
 * pdftoppm (Available in the AUR as **poppler** package.)
-* epub-thumbnailer
-* fontpreview
+* [epub-thumbnailer](https://github.com/marianosimone/epub-thumbnailer)
+* [fontpreview](https://github.com/sdushantha/fontpreview)
 
 ## Credits
 * Seebye for creating [Überzug](https://github.com/seebye/ueberzug) and the initial script
 that this script is heavily based upon.
 * [Ranger's](https://github.com/ranger/ranger) approach to file previewing as an
 inspiration source.
-

--- a/vifmimg
+++ b/vifmimg
@@ -89,6 +89,16 @@ function  previewaudio() {
     > "$FIFO_UEBERZUG"
 }
 
+function previewfont() {
+  if [[ ! -f "/tmp${PWD}/$6.png" ]]; then
+    fontpreview -i "$6" -o "/tmp${PWD}/$6.png"
+  fi
+  declare -p -A cmd=([action]=add [identifier]="$ID_PREVIEW"
+                     [x]="$2" [y]="$3" [width]="$4" [height]="$5" \
+                     [path]="/tmp${PWD}/$6.png") \
+    > "$FIFO_UEBERZUG"
+}
+
 function previewgif() {
     if [[ ! -d "/tmp$PWD/$6/" ]]; then
         mkdir -p "/tmp$PWD/$6/"
@@ -159,6 +169,7 @@ function main() {
         "pdfpreview") previewpdf "$@" ;;
         "magickpreview") previewmagick "$@" ;;
 	  "audiopreview") previewaudio "$@" ;;
+	  "fontpreview") previewfont "$@" ;;
         "*") echo "Unknown command: '$@'" ;;
     esac
 }


### PR DESCRIPTION
Hey,

I added support for previewing font files such as `*.otf`, `*.ttf` and `*.woff`. For this to work, [fontpreview](https://github.com/sdushantha/fontpreview) is needed.
All credits for this idea goes to @krasjet.

![image](https://user-images.githubusercontent.com/27065646/76287912-d6238780-62a5-11ea-84e7-2ee50fcb38e0.png)
