### PR TITLE
Correct README.md and make vifmrun works with local install ueberzug

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ variable for easy access to the files.
         \ vifmimg clear
         
     fileviewer <audio/*>
-        \ vifmimg audio %px %py %pw %ph %c
+        \ vifmimg audiopreview %px %py %pw %ph %c
         \ %pc
         \ vifmimg clear
         
     fileviewer <font/*>
-        \ vifmimg font %px %py %pw %ph %c
+        \ vifmimg fontpreview %px %py %pw %ph %c
         \ %pc
         \ vifmimg clear
 ```

--- a/vifmrun
+++ b/vifmrun
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 export FIFO_UEBERZUG="/tmp/vifm-ueberzug-${PPID}"
 
-if [ ! -f "/usr/bin/ueberzug" ]; then
+# this should work with both local and global ueberzug install
+if [ ! -x $(command -v ueberzug >/dev/null 2>&1) ]; then
 	vifm
 	exit
 fi


### PR DESCRIPTION
It seems like your README and vifmimg scripts doesn't match at font and audio preview in vifmrc section.
Another thing is, I install ueberzug in my ~/.local/bin/ueberzug and your scripts doesn't work. I thinks checking in $PATH is more flexible.
Thanks for reviewing