### PR TITLE
fix default case statement in main()

### DIFF
--- a/vifmimg
+++ b/vifmimg
@@ -168,9 +168,9 @@ function main() {
         "gifpreview") previewgif "$@" ;;
         "pdfpreview") previewpdf "$@" ;;
         "magickpreview") previewmagick "$@" ;;
-	  "audiopreview") previewaudio "$@" ;;
-	  "fontpreview") previewfont "$@" ;;
-        "*") echo "Unknown command: '$@'" ;;
+        "audiopreview") previewaudio "$@" ;;
+        "fontpreview") previewfont "$@" ;;
+        *) echo "Unknown command: '$@'" ;;
     esac
 }
 main "$@"


### PR DESCRIPTION
The program, when supplied with wrong arguments does not (at least for me) return any error.
I know that it is only a little change, but it might help others while troubleshooting their scripts.

Apart from that, I also changed the tabs at the beginning of the two lines above to spaces.