### PR TITLE
code cleanup

### DIFF
--- a/vifmimg
+++ b/vifmimg
@@ -49,7 +49,7 @@ main() {
 			image "$1" "$2" "$3" "$4" "$5" "${CACHE}.jpg"
 			;;
         *)
-			echo "Unknown command: '$@'"
+			echo "Unknown command: " "$@"
 			;;
     esac
 }

--- a/vifmrun
+++ b/vifmrun
@@ -1,18 +1,18 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-if [ -z "$(whereis ueberzug | awk '{print $2}')" ]; then
+test -z "$(which ueberzug )" &&
 	exec vifm "$@" && exit
-elif [ -z "$DISPLAY" ]; then
+
+test -z "$DISPLAY" &&
 	exec vifm "$@" && exit
-else
-	cleanup() {
-	    rm "$FIFO_UEBERZUG"
-	    pkill -P $$ >/dev/null
-	}
-	[ ! -d "$HOME/.cache/vifm" ] && mkdir --parents "$HOME/.cache/vifm"
-	export FIFO_UEBERZUG="$HOME/.cache/vifm/ueberzug-${PPID}"
-	mkfifo "$FIFO_UEBERZUG"
-	tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser bash 2>&1 >/dev/null &
-	trap cleanup EXIT
-	vifm "$@"
-fi
+
+cleanup() {
+    rm "$FIFO_UEBERZUG"
+    pkill -P $$ >/dev/null
+}
+! test -d "$HOME/.cache/vifm" && mkdir -p "$HOME/.cache/vifm"
+export FIFO_UEBERZUG="$HOME/.cache/vifm/ueberzug-${PPID}"
+mkfifo "$FIFO_UEBERZUG"
+tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser bash >/dev/null 2>&1 &
+trap cleanup EXIT
+vifm "$@"


### PR DESCRIPTION
- There is no need for `if` cause there is `&& exit`
- `vifmrun` is posix, so use `/bin/sh` for faster speed 🤷why not🤷
- also minor fix in vifmimg when echoing error choice.

(Checkout `shellcheck` it helps you a lot.)

(Also __i think__ that in `vifmrun`, the last command should be `cleanup`, but this PR is just to write the same code cleaner/faster.)