### PR TITLE
Suppress printing ffmpeg banner

### DIFF
--- a/vifmimg
+++ b/vifmimg
@@ -35,7 +35,7 @@ main() {
 			;;
         "audio")
 			[ ! -f "${PCACHE}.jpg" ] && \
-				ffmpeg -i "$6" "${PCACHE}.jpg" -y >/dev/null
+				ffmpeg -hide_banner -i "$6" "${PCACHE}.jpg" -y >/dev/null
 			image "$1" "$2" "$3" "$4" "$5" "${PCACHE}.jpg"
 			;;
         "font")


### PR DESCRIPTION
When generating a preview for an audio file, if `vifmimg` does not get an image,
it prints the a `ffmpeg`'s output to the `vifm` preview window.

This PR suppresses printing of ffmpeg's copyright notice, build options and library
versions inside vifm's preview window.